### PR TITLE
Fix build on Linux

### DIFF
--- a/tables/GenerateDenseCount.cpp
+++ b/tables/GenerateDenseCount.cpp
@@ -84,7 +84,7 @@ using namespace std;
 
 std::vector<uint8_t> message;
 
-static std::atomic<unsigned> FailedTrials = 0;
+static std::atomic<unsigned> FailedTrials(0);
 
 static void RandomTrial(
     unsigned N,

--- a/tables/GenerateMostDenseSeeds.cpp
+++ b/tables/GenerateMostDenseSeeds.cpp
@@ -222,7 +222,7 @@ void FillSeeds()
 
 std::vector<uint8_t> message;
 
-static std::atomic<unsigned> FailedTrials = 0;
+static std::atomic<unsigned> FailedTrials(0);
 
 static void RandomTrial(
     unsigned N,

--- a/tables/GeneratePeelSeeds.cpp
+++ b/tables/GeneratePeelSeeds.cpp
@@ -92,7 +92,7 @@ void FillSeeds()
     memcpy(kPeelSeeds, wirehair::kPeelSeeds, sizeof(kPeelSeeds));
 }
 
-static std::atomic<unsigned> FailedTrials = 0;
+static std::atomic<unsigned> FailedTrials(0);
 
 uint8_t Message[64000];
 

--- a/tables/GenerateSmallDenseSeeds.cpp
+++ b/tables/GenerateSmallDenseSeeds.cpp
@@ -94,7 +94,7 @@ static const int N_List[] = {
 
 uint8_t Message[64000];
 
-static std::atomic<unsigned> FailedTrials = 0;
+static std::atomic<unsigned> FailedTrials(0);
 
 static void RandomTrial(
     unsigned N,

--- a/tables/TableGenerator.cpp
+++ b/tables/TableGenerator.cpp
@@ -36,6 +36,7 @@ using namespace siamese;
 #include <vector>
 #include <algorithm>
 #include <iomanip>
+#include <cmath>
 using namespace std;
 
 #ifdef _MSC_VER

--- a/test/UnitTest.cpp
+++ b/test/UnitTest.cpp
@@ -519,7 +519,7 @@ static bool Test_DecodeRandomLosses(
     return true;
 }
 
-static atomic<bool> TestFailed = false;
+static atomic<bool> TestFailed(false);
 
 static void TestN(uint64_t seed, int N, unsigned blockBytes)
 {


### PR DESCRIPTION
Hi, building wirehair currently fails on Linux with (at least) gcc 4.8.5 (CentOS) and gcc 8.2.1 (Arch) because of the following errors:

```
error: use of deleted function ‘std::atomic<unsigned int>::atomic(const std::atomic<unsigned int>&)
error: use of deleted function ‘std::atomic<bool>::atomic(const std::atomic<bool>&)
```

The copy-constructor of std::atomic<> has been deleted, first commit of this PR fixes the issue by doing direct-initialization instead of copy-initialization.

also this error:
`error: ‘sqrt’ was not declared in this scope`
fixed in second commit by including cmath.

Thank you !