### PR TITLE
Update the cmake file to rely more on default or preset values.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(wirehair)
 
-set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
-
 set(CMAKE_CXX_STANDARD 11)
 
 set(LIB_SOURCE_FILES
@@ -56,10 +54,6 @@ set(GEN_TABLES
         gf256.h
         )
 
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release)
-endif()
-
 if(MSVC)
 else()
     set(CMAKE_CXX_FLAGS "-Wall -Wextra")
@@ -69,7 +63,9 @@ endif()
 
 include_directories(.)
 
-add_library(wirehair STATIC ${LIB_SOURCE_FILES})
+add_library(wirehair ${LIB_SOURCE_FILES})
+set_target_properties(wirehair PROPERTIES VERSION 2)
+set_target_properties(wirehair PROPERTIES SOVERSION 2)
 set_target_properties(wirehair PROPERTIES PUBLIC_HEADER wirehair.h)
 
 add_executable(unit_test ${UNIT_TEST_SOURCE_FILES})
@@ -89,32 +85,8 @@ target_link_libraries(gen_dcounts wirehair)
 
 add_executable(gen_tables ${GEN_TABLES})
 
-add_library(wirehair-shared SHARED ${LIB_SOURCE_FILES})
-set_target_properties(wirehair-shared PROPERTIES VERSION 2)
-set_target_properties(wirehair-shared PROPERTIES SOVERSION 2)
-set_target_properties(wirehair-shared PROPERTIES PUBLIC_HEADER wirehair.h)
-
-add_executable(unit_test_shared ${UNIT_TEST_SOURCE_FILES})
-target_link_libraries(unit_test_shared wirehair-shared)
-
-add_executable(gen_small_dseeds_shared ${GEN_SMALL_DSEEDS})
-target_link_libraries(gen_small_dseeds_shared wirehair-shared)
-
-add_executable(gen_peel_seeds_shared ${GEN_PEEL_SEEDS})
-target_link_libraries(gen_peel_seeds_shared wirehair-shared)
-
-add_executable(gen_most_dseeds_shared ${GEN_MOST_DSEEDS})
-target_link_libraries(gen_most_dseeds_shared wirehair-shared)
-
-add_executable(gen_dcounts_shared ${GEN_DCOUNTS})
-target_link_libraries(gen_dcounts_shared wirehair-shared)
-
 include(GNUInstallDirs)
 
 install(TARGETS wirehair
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-install(TARGETS wirehair-shared
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
The current version of the cmake file builds both the shared and static version of the library, which is unlikely the use case as a project is very unlikely to import a library as a shared library and a static library at the same time. While the current setting leads to an error when building the library using Visual Studio 2019, also this hinders inclusion of the library by package managers such as vcpkg.
Since cmake 3, the recommended approach to support static and shared libraries is to expect users to set BUILD_SHARED_LIBS. Setting it ON, the output become shared libraries, while static libraries are the result by default.
Besides that, this pull request includes removing setting CMAKE_CONFIGURATION_TYPES and CMAKE_BUILD_TYPE since setting CMAKE_CONFIGURATION_TYPES removes RelWithDebInfo and RelMinSize as options for Windows without improvements for other platforms as far as I know, and since not setting CMAKE_BUILD_TYPE results in a release build.

Thanks a lot for a wonderful library and let me know if you have different opinions!