### PR TITLE
Fix redundant redeclaration warning for gf256_memswap

### DIFF
--- a/gf256.h
+++ b/gf256.h
@@ -272,10 +272,6 @@ static GF256_FORCE_INLINE void gf256_div_mem(void * GF256_RESTRICT vz,
 //------------------------------------------------------------------------------
 // Misc Operations
 
-/// Swap two memory buffers in-place
-extern void gf256_memswap(void * GF256_RESTRICT vx, void * GF256_RESTRICT vy, int bytes);
-
-
 #ifdef __cplusplus
 }
 #endif // __cplusplus


### PR DESCRIPTION
gf256_memswap function is declared twice in gf256.h and
that generates lots of redundant redeclaration warnings.
This change will remove one of the declarations.