### PR TITLE
Include cstdlib on wirehair tools

### DIFF
--- a/WirehairTools.cpp
+++ b/WirehairTools.cpp
@@ -30,6 +30,7 @@
 #include "WirehairTools.h"
 
 #include <cmath>
+#include <cstdlib>
 
 #ifdef _MSC_VER
 #include <intrin.h> // _BitScanReverse


### PR DESCRIPTION
The compilation was failing without this include when using gcc 6.3.0 on Debian stretch.

It's easy to reproduce on a Docker container. Launch with:

```
docker run --rm -it buildpack-deps:stretch
```

Install cmake:
```
apt update && apt install -y cmake
```

And build:
```
git clone https://github.com/catid/wirehair.git
cd wirehair
mkdir build && cd build/
cmake ..
make
```

Result:
```
/wirehair/WirehairTools.cpp: In function 'uint8_t* wirehair::SIMDSafeAllocate(size_t)':
/wirehair/WirehairTools.cpp:577:65: error: 'calloc' was not declared in this scope
     uint8_t* data = (uint8_t*)calloc(1, GF256_ALIGN_BYTES + size);
                                                                 ^
/wirehair/WirehairTools.cpp: In function 'void wirehair::SIMDSafeFree(void*)':
/wirehair/WirehairTools.cpp:599:14: error: 'free' was not declared in this scope
     free(data);
              ^
CMakeFiles/wirehair.dir/build.make:134: recipe for target 'CMakeFiles/wirehair.dir/WirehairTools.cpp.o' failed
make[2]: *** [CMakeFiles/wirehair.dir/WirehairTools.cpp.o] Error 1
CMakeFiles/Makefile2:252: recipe for target 'CMakeFiles/wirehair.dir/all' failed
make[1]: *** [CMakeFiles/wirehair.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
```