### PR TITLE
Add m_init check in wirehair_decoder_create().

### DIFF
--- a/wirehair.cpp
+++ b/wirehair.cpp
@@ -153,7 +153,7 @@ WIREHAIR_EXPORT WirehairCodec wirehair_decoder_create(
 )
 {
     // If input is invalid:
-    if (messageBytes < 1 || blockBytes < 1) {
+    if (!m_init || messageBytes < 1 || blockBytes < 1) {
         return nullptr;
     }
 


### PR DESCRIPTION
Being so dumb, I spent a day only to learn that I did not call the init function...

This PR is for at least turning my experience into something useful...