### PR TITLE
Make -march=native optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,8 @@ set(GEN_TABLES
 if(MSVC)
 else()
     set(CMAKE_CXX_FLAGS "-Wall -Wextra")
-    set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -march=native")
-    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native")
+    set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 endif()
 
 add_library(wirehair ${LIB_SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(wirehair)
 
 set(CMAKE_CXX_STANDARD 11)
 
+option(MARCH_NATIVE "Use -march=native option" ON)
+
 set(LIB_SOURCE_FILES
         wirehair.cpp
         include/wirehair/wirehair.h
@@ -59,6 +61,11 @@ else()
     set(CMAKE_CXX_FLAGS "-Wall -Wextra")
     set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+endif()
+
+if(MARCH_NATIVE)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -march=native")
+    set(MAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
 endif()
 
 add_library(wirehair ${LIB_SOURCE_FILES})


### PR DESCRIPTION
Using Apple clang 12.0.5, to build for iOS with CMake, the below error happens.
clang: error: the clang compiler does not support '-march=native'

I am not sure but my guess is -march=native is for utilizing the instruction set of the build machine, so perhaps someone thought supporting it for a cross compilation did not make sense. I'm not sure but below are all I've found from forums:
https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1
https://developer.apple.com/forums/thread/672654

By the way, my machine is an x86-64, not an M1, so this is not something M1 chip specific.

So, I added an option to deactivate -march=native. Also, thanks for the recent ios-fix update with LINUX_ARM!