### PR TITLE
Fix comment in wirehair.h

### DIFF
--- a/include/wirehair/wirehair.h
+++ b/include/wirehair/wirehair.h
@@ -243,7 +243,7 @@ WIREHAIR_EXPORT WirehairResult wirehair_decode(
 );
 
 /**
-    wirehair_reconstruct()
+    wirehair_recover()
 
     Reconstruct the message after reading is complete.
 


### PR DESCRIPTION
Rename wirehair_reconstruct to wirehair_recover since wirehair_reconstruct isn't referenced anywhere in the codebase.