### PR TITLE
Patch CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,11 +69,13 @@ else()
     set(CMAKE_CXX_FLAGS "-Wall -Wextra")
     set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O3")
 endif()
 
 if(MARCH_NATIVE)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -march=native")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -march=native")
 endif()
 
 add_library(wirehair ${LIB_SOURCE_FILES})


### PR DESCRIPTION
Fix CMakeLists.txt when building with `RelWithDebInfo` profile.

By the way, the fork was mainly for providing a Rust binding for the library. The binding is fairly straightforward and ready to use. Any interest in merging that as well?