### PR TITLE
support macOS arm

### DIFF
--- a/gf256.h
+++ b/gf256.h
@@ -54,12 +54,12 @@
 // Platform/Architecture
 
 #if defined(__ARM_ARCH) || defined(__ARM_NEON) || defined(__ARM_NEON__)
-    #if !defined IOS
+    #if !defined(__APPLE__)
         #define LINUX_ARM
     #endif
 #endif
 
-#if defined(ANDROID) || defined(IOS) || defined(LINUX_ARM) || defined(__powerpc__) || defined(__s390__)
+#if defined(ANDROID) || defined(__ARM_ARCH) || defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__powerpc__) || defined(__s390__)
     #define GF256_TARGET_MOBILE
 #endif // ANDROID
 


### PR DESCRIPTION
I met compilation errors on macOS arm.
This error seems to be caused by 2 reasons.

First, LINUX_ARM is falsely defined by macOS arm.
```cpp
#if defined(__ARM_ARCH) || defined(__ARM_NEON) || defined(__ARM_NEON__)
    #if !defined IOS
        #define LINUX_ARM
    #endif
#endif
```

It causes following compilation error.
```
gf256.cpp:35:10: fatal error: 'elf.h' file not found
   35 | #include <elf.h>
      |          ^~~~~~~
```

Second, tmmintrin.h is falsely included on macOS arm.
```
#if defined(ANDROID) || defined(IOS) || defined(LINUX_ARM) || defined(__powerpc__) || defined(__s390__)
    #define GF256_TARGET_MOBILE
#endif // ANDROID
```

It causes following compilation error due to including tmmintrin.h.
```
In file included from gf256.cpp:30:
In file included from gf256.h:75:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/16/include/tmmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
   14 | #error "This header is only meant to be used on x86 and x64 architecture"
      |  ^
```

This PR tries to fix these issues.
